### PR TITLE
trackeback prints regardless of entering UI #53

### DIFF
--- a/wtpython/__main__.py
+++ b/wtpython/__main__.py
@@ -69,8 +69,8 @@ def main() -> None:
         print(e)
         return
 
+    traceback.print_exception(type(exc), exc, exc.__traceback__)
     if flags['no_display']:
-        traceback.print_exception(type(exc), exc, exc.__traceback__)
         print(so_results)
     else:
         store_results_in_module(exc, so_results)

--- a/wtpython/__main__.py
+++ b/wtpython/__main__.py
@@ -69,7 +69,7 @@ def main() -> None:
         print(e)
         return
 
-    traceback.print_exception(type(exc), exc, exc.__traceback__)
+    print(''.join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
     if flags['no_display']:
         print(so_results)
     else:


### PR DESCRIPTION
this allows wtpython to run transparently if there's no issue