### PR TITLE
Change next question shortcut from `l`- `j`

### DIFF
--- a/wtpython/display.py
+++ b/wtpython/display.py
@@ -101,7 +101,7 @@ class Display(App):
 
         # Vim shortcuts...
         await self.bind("k", "prev_question")
-        await self.bind("l", "next_question")
+        await self.bind("j", "next_question")
 
     def create_body_text(self) -> RenderableType:
         """Return the text to display in the ScrollView"""


### PR DESCRIPTION
I don't think `k` and `l` are ergonomic. Any people familiar with `vim` would naturally gravitate towards `j` and `k`, which is why I set those as the shortcuts in the first place.