### PR TITLE
Don't run license check on every push / PR.

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -1,6 +1,12 @@
 name: MIT license compatibility checker
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - pyproject.toml
+  pull_request:
+    paths:
+      - pyproject.toml
 
 concurrency: lint-${{ github.sha }}
 


### PR DESCRIPTION
It doesn't make sense to run this workflow unless the
`pyproject.toml` file has changed. Github allows us to condition
the run only on changes of certain files

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-paths