### PR TITLE
fix incorrect traceback extraction where filename contains runpy

### DIFF
--- a/wtpython/__main__.py
+++ b/wtpython/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import runpy
 import sys
 import traceback
+from pathlib import Path
 
 import pyperclip
 from rich import print
@@ -26,10 +27,10 @@ def trim_exception_traceback(tb: traceback) -> traceback:
     seen_runpy = False
     while tb is not None:
         cur = tb.tb_frame
-        filename = cur.f_code.co_filename
-        if "runpy" in filename:
+        filename = Path(cur.f_code.co_filename).name
+        if filename == "runpy.py":
             seen_runpy = True
-        elif seen_runpy and "runpy" not in filename:
+        elif seen_runpy and filename != "runpy.py":
             break
         tb = tb.tb_next
 


### PR DESCRIPTION
currently if the script name has "runpy" in it, it's skipping over that line of traceback

xref: https://github.com/what-the-python/wtpython/pull/81#discussion_r671575109