### PR TITLE
Remove `on: pull_request` for pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,7 @@
 
 name: pytest
 
-on: [push, pull_request]
+on: push
 
 concurrency: lint-${{ github.sha }}
 


### PR DESCRIPTION
We already have the workflow running on every push, and currently it seems that it is run twice on a pull request (once for the push and once for the PR). No need to do twice the work :)