### PR TITLE
Add command line option to clear the HTTP cache

### DIFF
--- a/wtpython/__main__.py
+++ b/wtpython/__main__.py
@@ -89,6 +89,12 @@ def parse_arguments() -> tuple[dict, list]:
         default=False,
         help="Copy error to clipboard",
     )
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        default=False,
+        help="Clear StackOverflow cache",
+    )
 
     flags, args = parser.parse_known_args()
     if not args:
@@ -114,7 +120,8 @@ def main() -> None:
     if flags["copy_error"]:
         pyperclip.copy(error)
 
-    so = StackOverflowFinder()
+    so = StackOverflowFinder(clear_cache=flags["clear_cache"])
+
     try:
         so_results = so.search(error, MAX_SO_RESULTS)
     except SearchError as e:

--- a/wtpython/backends/stackoverflow.py
+++ b/wtpython/backends/stackoverflow.py
@@ -41,6 +41,9 @@ class StackOverflowQuestion:
 class StackOverflowFinder:
     """Get results from Stack Overflow"""
 
+    def __init__(self, clear_cache: bool = False):
+        self.clear_cache = clear_cache
+
     def search(self, error_message: str, max_results: int = 5) -> List[StackOverflowQuestion]:
         """Search Stack Overflow with the initialized SE API object"""
         # Initialize the cache for the HTTP requests, and the session
@@ -49,6 +52,8 @@ class StackOverflowFinder:
             backend=FileCache(REQUEST_CACHE_LOCATION),
             expire_after=REQUEST_CACHE_DURATION,
         )
+        if self.clear_cache:
+            session.cache.clear()
 
         result = session.get(
             "https://api.stackexchange.com/2.3/search",


### PR DESCRIPTION
Solves #87

Perhaps the design could be improved. Currently the `StackOverflowFinder()` takes a boolean in the constructor to tell it to clear the cache before performing any requests.