### PR TITLE
3.7+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,14 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 description-file = "README.md"
-requires-python=">=3.9"
+requires-python=">=3.7"
 requires=[
     "parse == 1.19.0",
     "requests == 2.25.1",

--- a/wtpython/__init__.py
+++ b/wtpython/__init__.py
@@ -4,5 +4,3 @@ __version__ = "0.1"
 
 class SearchError(Exception):
     """Custom Error for Searching for External Data."""
-
-    pass

--- a/wtpython/__main__.py
+++ b/wtpython/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os.path
 import runpy

--- a/wtpython/display.py
+++ b/wtpython/display.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import html
 import traceback
 import webbrowser

--- a/wtpython/stackoverflow.py
+++ b/wtpython/stackoverflow.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import html
-from typing import List
 
 from requests_cache import CachedSession
 from requests_cache.backends import FileCache
@@ -58,7 +59,7 @@ class StackOverflowQuestion:
         self.score: int = question_json["score"]
         self.body: str = question_json["body"]
 
-        self.answers: List[StackOverflowAnswer] = [StackOverflowAnswer(x) for x in answer_json["items"]]
+        self.answers: list[StackOverflowAnswer] = [StackOverflowAnswer(x) for x in answer_json["items"]]
         self.answers.sort(key=lambda x: (x.is_accepted, x.score), reverse=True)
 
     def __str__(self):
@@ -88,7 +89,7 @@ class StackOverflowFinder:
         response = self.session.get(f"{SO_API}/questions/{question['question_id']}/answers", params=params)
         return response.json()
 
-    def search(self, error_message: str, max_results: int = SO_MAX_RESULTS) -> List[StackOverflowQuestion]:
+    def search(self, error_message: str, max_results: int = SO_MAX_RESULTS) -> list[StackOverflowQuestion]:
         """Search Stack Overflow for relevant questions."""
         params = {
             "pagesize": max_results,


### PR DESCRIPTION
This removes 3.9-specific type annotations and solves #114.

Tested on `python:3.7-alpine`, `python:3.8-alpine`, `python:3.9-alpine`, and `python:3.10-rc-alpine`.